### PR TITLE
Change all ToString methods to Go's fmt.Stringer

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -93,7 +93,7 @@ func main() {
 }
 
 func printTree(all []*disjunction.Disjunction, d *disjunction.Disjunction, indent string, left bool) {
-	text := d.ToString()
+	text := d.String()
 
 	if len(indent) > 0 {
 		if left {
@@ -139,13 +139,13 @@ func getDisjunction(id int, all []*disjunction.Disjunction) *disjunction.Disjunc
 
 func printDisjunctions(disjunctions []*disjunction.Disjunction) {
 	for _, d := range disjunctions {
-		fmt.Println(fmt.Sprintf("%d %s", d.ID(), d.ToString()))
+		fmt.Println(fmt.Sprintf("%d %s", d.ID(), d.String()))
 	}
 }
 
 func printCombinations(combinations []*disjunction.Disjunction) {
 	for _, c := range combinations {
-		fmt.Println(fmt.Sprintf("%d %s %d %d", c.ID(), c.ToString(), c.SourceA, c.SourceB))
+		fmt.Println(fmt.Sprintf("%d %s %d %d", c.ID(), c.String(), c.SourceA, c.SourceB))
 	}
 }
 

--- a/pkg/disjunction/disjunction.go
+++ b/pkg/disjunction/disjunction.go
@@ -30,10 +30,10 @@ func (d *Disjunction) IsEmpty() bool {
 	return len(d.literals) == 0
 }
 
-// ToString stringifies the disjunction.
+// String stringifies the disjunction.
 //
 // Example: "(!a | b | c)"
-func (d *Disjunction) ToString() string {
+func (d *Disjunction) String() string {
 	text := "( "
 
 	length := len(d.literals)

--- a/pkg/disjunction/disjunction_test.go
+++ b/pkg/disjunction/disjunction_test.go
@@ -168,10 +168,10 @@ func TestDisjunctionToString(t *testing.T) {
 	disjunctions := setup()
 
 	toStrings := []string{
-		disjunctions[0].ToString(),
-		disjunctions[1].ToString(),
-		disjunctions[2].ToString(),
-		disjunctions[3].ToString(),
+		disjunctions[0].String(),
+		disjunctions[1].String(),
+		disjunctions[2].String(),
+		disjunctions[3].String(),
 	}
 
 	results := []string{

--- a/pkg/literal/literal.go
+++ b/pkg/literal/literal.go
@@ -38,8 +38,8 @@ func (l *Literal) Opposes(other *Literal) bool {
 	return l.variable == other.variable && l.negated != other.negated
 }
 
-// ToString prints the literal as string
-func (l *Literal) ToString() string {
+// String prints the literal as string
+func (l *Literal) String() string {
 	text := ""
 	if l.negated {
 		text += "!"

--- a/pkg/literal/literal_test.go
+++ b/pkg/literal/literal_test.go
@@ -121,10 +121,10 @@ func TestLiteralToString(t *testing.T) {
 	}
 
 	toString := []string{
-		a.ToString(),
-		aNeg.ToString(),
-		b.ToString(),
-		bNeg.ToString(),
+		a.String(),
+		aNeg.String(),
+		b.String(),
+		bNeg.String(),
 	}
 
 	expected := []string{


### PR DESCRIPTION
This Pull Request changes all `* ToString() string` methods in the project to a more "Go-like" `* String() string`, as this is the built in way to determine how objects should be represented as strings (and used accross the fmt package in the standard library).

Furthermore this ensures interoperabiltiy with other libraries and packages, when the project expands

Read more here: https://golang.org/pkg/fmt/#Stringer